### PR TITLE
Configure Sentry with custom logging filter

### DIFF
--- a/ask_hn_digest/sentry_utils.py
+++ b/ask_hn_digest/sentry_utils.py
@@ -1,0 +1,22 @@
+from logging import LogRecord
+
+from sentry_sdk.integrations.logging import LoggingIntegration
+
+_IGNORED_LOGGERS = {"ask_hn_digest"}
+
+class CustomLoggingIntegration(LoggingIntegration):
+    def _handle_record(self, record: LogRecord) -> None:
+        # This match upper logger names, e.g. "celery" will match "celery.worker"
+        # or "celery.worker.job"
+        if record.name in _IGNORED_LOGGERS or record.name.split(".")[0] in _IGNORED_LOGGERS:
+            return
+        super()._handle_record(record)
+
+
+def before_send(event, hint):
+    if "exc_info" in hint:
+        exc_type, exc_value, tb = hint["exc_info"]
+
+        if isinstance(exc_value, SystemExit):  # group all SystemExits together
+            event["fingerprint"] = ["system-exit"]
+    return event

--- a/ask_hn_digest/settings.py
+++ b/ask_hn_digest/settings.py
@@ -12,10 +12,13 @@ https://docs.djangoproject.com/en/4.0/ref/settings/
 
 import os
 from pathlib import Path
+from ask_hn_digest.sentry_utils import CustomLoggingIntegration
 import environ
 import structlog
 import logging
 import sentry_sdk
+from sentry_sdk.integrations.logging import LoggingIntegration
+
 import structlog
 from structlog_sentry import SentryProcessor
 
@@ -313,7 +316,16 @@ if ENVIRONMENT == "prod":
 
 SENTRY_DSN = env("SENTRY_DSN")
 if ENVIRONMENT == "prod" and SENTRY_DSN:
-    sentry_sdk.init(dsn=env("SENTRY_DSN"))
+    sentry_sdk.init(
+        dsn=SENTRY_DSN,
+        integrations=[
+            LoggingIntegration(
+                level=None,
+                event_level=None
+            ),
+            CustomLoggingIntegration(event_level=logging.ERROR)
+        ],
+    )
 
 POSTHOG_API_KEY = env("POSTHOG_API_KEY")
 


### PR DESCRIPTION
Implement a custom Sentry logging integration
(`CustomLoggingIntegration`) to prevent logs originating from the `ask_hn_digest` logger and its children from being sent to Sentry. This reduces noise from internal logging that doesn't represent application errors.

Define a `before_send` hook (`sentry_utils.before_send`) to group all `SystemExit` exceptions into a single Sentry issue using a custom fingerprint. This prevents a multitude of `SystemExit` issues from cluttering Sentry.

Update Sentry initialization in `settings.py` to use the `CustomLoggingIntegration` for error-level logs.