### PR TITLE
Fix invalid split filter error

### DIFF
--- a/core/templatetags/markdown_extras.py
+++ b/core/templatetags/markdown_extras.py
@@ -10,9 +10,7 @@ register = template.Library()
 @stringfilter
 def markdown(value):
     md_instance = md.Markdown(extensions=["tables"])
-
     html = md_instance.convert(value)
-
     return mark_safe(html)
 
 

--- a/frontend/templates/components/article_card.html
+++ b/frontend/templates/components/article_card.html
@@ -1,3 +1,4 @@
+{% load markdown_extras %}
 <div class="p-6 bg-white rounded-lg border border-orange-100 shadow-md relative" 
      data-controller="likes" 
      data-likes-article-id-value="{{ article.id }}"


### PR DESCRIPTION
Fix `TemplateSyntaxError: Invalid filter: 'split'` by explicitly loading `markdown_extras` templatetags in `article_card.html` and cleaning up `markdown` filter formatting.

---
[Slack Thread](https://rasulsworkspace.slack.com/archives/C094T44RL9F/p1753957800418049?thread_ts=1753957800.418049&cid=C094T44RL9F)

<a href="https://cursor.com/background-agent?bcId=bc-5e4eae4a-358a-443b-8936-99f11d46541b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5e4eae4a-358a-443b-8936-99f11d46541b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>