### PR TITLE
Sync article card design on bookmarked and liked pages

### DIFF
--- a/frontend/src/controllers/saved_articles_controller.js
+++ b/frontend/src/controllers/saved_articles_controller.js
@@ -41,19 +41,68 @@ export default class extends Controller {
       day: 'numeric'
     })
 
+    // Create tags HTML if article has tags
+    const tagsHTML = article.tags ? 
+      article.tags.split(',').map(tag => {
+        const trimmedTag = tag.trim()
+        if (trimmedTag) {
+          return `<span class="inline-block px-2 py-1 text-xs font-medium text-orange-700 bg-orange-100 rounded-full">${this.escapeHtml(trimmedTag)}</span>`
+        }
+        return ''
+      }).filter(tag => tag).join('') : ''
+
     return `
-      <div class="p-6 bg-white rounded-lg border border-orange-100 shadow-md relative">
-        <div class="pr-20">
-          <div class="mb-2">
-            <a href="/blog/${article.slug}" class="text-xl font-bold text-orange-700 hover:text-orange-800 hover:underline">
-              ${this.escapeHtml(article.title)}
-            </a>
+      <div class="relative p-6 bg-white rounded-lg border border-orange-100 shadow-md"
+           data-controller="likes"
+           data-likes-article-id-value="${article.id}"
+           data-likes-article-slug-value="${article.slug}"
+           data-likes-article-title-value="${this.escapeHtml(article.title)}">
+
+        <!-- Like and Bookmark buttons in top right -->
+        <div class="flex absolute top-4 right-4 space-x-2">
+          <!-- Like button -->
+          <button data-action="click->likes#like"
+                  data-likes-target="likeButton"
+                  class="p-2 text-gray-400 rounded-full transition-colors hover:bg-gray-100 hover:text-red-500"
+                  title="Like this article">
+            <svg data-likes-target="likeIcon" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"></path>
+            </svg>
+          </button>
+
+          <!-- Bookmark button -->
+          <button data-action="click->likes#bookmark"
+                  data-likes-target="bookmarkButton"
+                  class="p-2 text-gray-400 rounded-full transition-colors hover:bg-gray-100 hover:text-blue-500"
+                  title="Bookmark this article">
+            <svg data-likes-target="bookmarkIcon" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"></path>
+            </svg>
+          </button>
+        </div>
+
+        <!-- Article content -->
+        <div>
+          <!-- Title and date area - needs right padding for buttons -->
+          <div class="pr-20 mb-3">
+            <div class="mb-2">
+              <a href="/blog/${article.slug}" class="text-xl font-bold text-orange-700 hover:text-orange-800 hover:underline">
+                ${this.escapeHtml(article.title)}
+              </a>
+            </div>
+            <div class="text-xs text-gray-500">
+              ${formattedDate}
+            </div>
           </div>
-          <div class="mb-3 text-xs text-gray-500">
-            ${actionText} on ${formattedDate}
-          </div>
-          <div class="flex justify-between items-center">
-            <span class="text-sm text-gray-500">Article ID: ${article.id}</span>
+
+          <!-- Description and tags - can use full width -->
+          <p class="mb-4 text-gray-700">
+            ${this.escapeHtml(article.description || '')}
+          </p>
+          ${tagsHTML ? `<div class="flex flex-wrap gap-2">${tagsHTML}</div>` : ''}
+          
+          <!-- Remove button at bottom -->
+          <div class="mt-4 text-right">
             <button data-action="click->saved-articles#removeArticle" 
                     data-article-id="${article.id}"
                     class="text-sm text-red-500 hover:text-red-700 underline">


### PR DESCRIPTION
Refactor bookmarked and liked article cards to match the homepage's visual design and functionality.

---
[Slack Thread](https://rasulsworkspace.slack.com/archives/C094T44RL9F/p1756817013536029?thread_ts=1756817013.536029&cid=C094T44RL9F)

<a href="https://cursor.com/background-agent?bcId=bc-cc2174e3-6ba0-4048-a6a5-4abd4fede08b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cc2174e3-6ba0-4048-a6a5-4abd4fede08b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

