### PR TITLE
[AI] Update Default Content Model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,11 +26,12 @@ MJML_APPLICATION_ID=...
 
 # AI runs through Pydantic AI and OpenRouter.
 # Content model names use OpenRouter model IDs.
+# Default content model favors low-cost, high-volume blog generation.
 OPENROUTER_API_KEY=
 OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 OPENROUTER_APP_URL=http://localhost:8006
 OPENROUTER_APP_TITLE="Ask HN Digest"
-AI_CONTENT_MODEL=google/gemini-2.5-flash
+AI_CONTENT_MODEL=google/gemini-3.1-flash-lite
 AI_EMBEDDING_MODEL=openai/text-embedding-3-small
 
 LOGFIRE_TOKEN=

--- a/ask_hn_digest/settings.py
+++ b/ask_hn_digest/settings.py
@@ -372,7 +372,8 @@ OPENROUTER_BASE_URL = env("OPENROUTER_BASE_URL", default="https://openrouter.ai/
 OPENROUTER_APP_URL = env("OPENROUTER_APP_URL", default="https://askhndigests.com")
 OPENROUTER_APP_TITLE = env("OPENROUTER_APP_TITLE", default="Ask HN Digest")
 
-AI_CONTENT_MODEL = env("AI_CONTENT_MODEL", default="google/gemini-2.5-flash")
+# Keep the default content model optimized for high-volume blog generation cost.
+AI_CONTENT_MODEL = env("AI_CONTENT_MODEL", default="google/gemini-3.1-flash-lite")
 AI_EMBEDDING_MODEL = env("AI_EMBEDDING_MODEL", default="openai/text-embedding-3-small")
 
 MJML_BACKEND_MODE = "httpserver"


### PR DESCRIPTION
## Summary
- Switches the default content-generation model from `google/gemini-2.5-flash` to `google/gemini-3.1-flash-lite`.
- Updates `.env.example` to match the production default.
- Keeps embeddings on `openai/text-embedding-3-small`, which is still the low-cost OpenAI embedding default.

## Why
OpenRouter lists `google/gemini-3.1-flash-lite` as a GA high-efficiency model for low-latency, high-volume workloads, with a 1M context window and $0.25/M input, $1.50/M output pricing: https://openrouter.ai/google/gemini-3.1-flash-lite

This is cheaper than the current `google/gemini-2.5-flash` default on output-heavy blog generation workloads. I considered `openai/gpt-5.4-mini` as the stronger writing/reasoning option, but its $0.75/M input and $4.50/M output pricing makes it a more expensive default for lots of monthly posts: https://developers.openai.com/api/docs/models/gpt-5.4-mini

## Validation
- `uv run ruff check ask_hn_digest/settings.py`
- `uv run python manage.py check` with local env values; it exits successfully with the existing warning that `frontend/build` is missing.
- `uv run pytest` collected 0 tests in this repo.
