### PR TITLE
[SEO] Address Audit Metadata and Schema Issues

### DIFF
--- a/ask_hn_digest/sitemaps.py
+++ b/ask_hn_digest/sitemaps.py
@@ -20,6 +20,7 @@ class StaticViewSitemap(sitemaps.Sitemap):
         return [
             "home",
             "blog_posts",
+            "tag_list",
         ]
 
     def location(self, item):
@@ -34,12 +35,26 @@ class StaticViewSitemap(sitemaps.Sitemap):
         return reverse(item)
 
 
+class TagSitemap(sitemaps.Sitemap):
+    """Generate sitemap entries for public tag archive pages."""
+
+    priority = 0.6
+    protocol = "https"
+
+    def items(self):
+        return HNDiscussionSummary.get_all_tags_with_counts()
+
+    def location(self, item):
+        return reverse("tag_detail", kwargs={"tag_slug": item.slug})
+
+
 sitemaps = {
     "static": StaticViewSitemap,
+    "tags": TagSitemap,
     "blog": GenericSitemap(
         {
             "queryset": HNDiscussionSummary.objects.all(),
-            "date_field": "created_at",
+            "date_field": "updated_at",
         },
         priority=0.85,
         protocol="https",

--- a/ask_hn_digest/sitemaps.py
+++ b/ask_hn_digest/sitemaps.py
@@ -1,5 +1,6 @@
 from django.contrib import sitemaps
 from django.contrib.sitemaps import GenericSitemap
+from django.db.models import Max
 from django.urls import reverse
 
 from core.models import HNDiscussionSummary
@@ -42,10 +43,15 @@ class TagSitemap(sitemaps.Sitemap):
     protocol = "https"
 
     def items(self):
-        return HNDiscussionSummary.get_all_tags_with_counts()
+        return HNDiscussionSummary.get_all_tags_with_counts().annotate(
+            latest_summary_updated_at=Max("summaries__updated_at")
+        )
 
     def location(self, item):
         return reverse("tag_detail", kwargs={"tag_slug": item.slug})
+
+    def lastmod(self, item):
+        return item.latest_summary_updated_at or item.updated_at
 
 
 sitemaps = {

--- a/ask_hn_digest/urls.py
+++ b/ask_hn_digest/urls.py
@@ -19,10 +19,12 @@ from django.contrib.sitemaps.views import sitemap
 from django.urls import include, path
 
 from ask_hn_digest.sitemaps import sitemaps
+from core.views import robots_txt
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("anymail/", include("anymail.urls")),
+    path("robots.txt", robots_txt, name="robots_txt"),
     path("", include("core.urls")),
     path(
         "sitemap.xml",

--- a/core/seo.py
+++ b/core/seo.py
@@ -9,9 +9,7 @@ DEFAULT_FONT = "markerfelt"
 
 
 def absolute_url(request, path_or_url):
-    if path_or_url.startswith(("http://", "https://")):
-        return path_or_url
-    return f"https://{request.get_host()}{path_or_url}"
+    return request.build_absolute_uri(path_or_url)
 
 
 def static_url(request, path):

--- a/core/seo.py
+++ b/core/seo.py
@@ -1,0 +1,115 @@
+from urllib.parse import urlencode
+
+from django.conf import settings
+from django.templatetags.static import static
+
+SITE_NAME = "Ask HN Digest"
+DEFAULT_DESCRIPTION = "Get summaries of the most engaging discussions on Hacker News."
+DEFAULT_FONT = "markerfelt"
+
+
+def absolute_url(request, path_or_url):
+    if path_or_url.startswith(("http://", "https://")):
+        return path_or_url
+    return f"https://{request.get_host()}{path_or_url}"
+
+
+def static_url(request, path):
+    try:
+        path_or_url = static(path)
+    except ValueError:
+        path_or_url = f"{settings.STATIC_URL}{path}"
+    return absolute_url(request, path_or_url)
+
+
+def clean_text(value):
+    return " ".join(str(value or "").split())
+
+
+def truncate_meta(value, max_length):
+    text = clean_text(value)
+    if len(text) <= max_length:
+        return text
+
+    truncated = text[: max_length - 3].rsplit(" ", 1)[0].rstrip(".,;:")
+    return f"{truncated}..."
+
+
+def discussion_description(summary, max_length=155):
+    description = summary.description or summary.short_summary or DEFAULT_DESCRIPTION
+    return truncate_meta(description, max_length)
+
+
+def discussion_title(summary, max_length=42):
+    return truncate_meta(summary.title, max_length)
+
+
+def post_image_url(request, summary):
+    image = getattr(summary, "image", None)
+    try:
+        if image:
+            return absolute_url(request, image.url)
+    except ValueError:
+        pass
+    return static_url(request, "vendors/images/logo.png")
+
+
+def social_image_url(request, title, description, image_url=None, style="base", site="x"):
+    params = {
+        "site": site,
+        "style": style,
+        "font": DEFAULT_FONT,
+        "title": clean_text(title),
+        "subtitle": clean_text(description),
+        "image_url": image_url or static_url(request, "vendors/images/logo.png"),
+    }
+    return f"https://osig.app/g?{urlencode(params)}"
+
+
+def blog_post_schema(request, summary, url, image_url):
+    return {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": clean_text(summary.title),
+        "description": clean_text(summary.description or summary.short_summary or DEFAULT_DESCRIPTION),
+        "image": image_url,
+        "url": url,
+        "datePublished": summary.created_at,
+        "dateModified": summary.updated_at,
+        "author": {
+            "@type": "Person",
+            "name": "Rasul Kireev",
+            "url": "https://rasulkireev.com/",
+        },
+        "publisher": {
+            "@type": "Organization",
+            "name": SITE_NAME,
+            "logo": {
+                "@type": "ImageObject",
+                "url": static_url(request, "vendors/images/logo.png"),
+            },
+        },
+        "keywords": summary.get_tags_list(),
+        "articleBody": clean_text(summary.long_summary),
+        "mainEntityOfPage": {
+            "@type": "WebPage",
+            "@id": url,
+        },
+    }
+
+
+def website_schema(request, url, name=SITE_NAME, description=DEFAULT_DESCRIPTION, image_url=None):
+    return {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "name": name,
+        "description": clean_text(description),
+        "thumbnailUrl": image_url or social_image_url(request, name, description, style="logo"),
+        "url": url,
+        "author": {
+            "@type": "Person",
+            "givenName": "Rasul",
+            "familyName": "Kireev",
+            "url": "https://rasulkireev.com/",
+        },
+    }

--- a/core/templatetags/seo_extras.py
+++ b/core/templatetags/seo_extras.py
@@ -1,0 +1,19 @@
+import json
+
+from django import template
+from django.core.serializers.json import DjangoJSONEncoder
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+_JSON_SCRIPT_ESCAPES = {
+    ord(">"): "\\u003E",
+    ord("<"): "\\u003C",
+    ord("&"): "\\u0026",
+}
+
+
+@register.filter
+def json_ld(value):
+    json_value = json.dumps(value, cls=DjangoJSONEncoder, ensure_ascii=True)
+    return mark_safe(json_value.translate(_JSON_SCRIPT_ESCAPES))

--- a/core/views.py
+++ b/core/views.py
@@ -18,6 +18,7 @@ from core.seo import (
     DEFAULT_DESCRIPTION,
     absolute_url,
     blog_post_schema,
+    clean_text,
     discussion_description,
     discussion_title,
     post_image_url,
@@ -151,17 +152,19 @@ class BlogPostView(DetailView):
         summary = self.object
         post_url = absolute_url(self.request, summary.get_absolute_url())
         seo_title = f"{discussion_title(summary)} | Ask HN Digest"
+        social_title = clean_text(summary.title)
         seo_description = discussion_description(summary)
         image_url = post_image_url(self.request, summary)
         generated_social_image_url = social_image_url(
             self.request,
-            title=seo_title,
+            title=social_title,
             description=seo_description,
             image_url=image_url,
         )
 
         context["canonical_url"] = post_url
         context["seo_title"] = seo_title
+        context["social_title"] = social_title
         context["seo_description"] = seo_description
         context["social_image_url"] = generated_social_image_url
         context["blog_post_schema"] = blog_post_schema(

--- a/core/views.py
+++ b/core/views.py
@@ -6,6 +6,7 @@ from django.db.models import Q
 from django.http import Http404, HttpResponse
 from django.shortcuts import redirect
 from django.template.loader import render_to_string
+from django.urls import reverse
 from django.utils.html import strip_tags
 from django.views.generic import DetailView, ListView, TemplateView
 from django_q.tasks import async_task
@@ -13,8 +14,39 @@ from django_q.tasks import async_task
 from ask_hn_digest.utils import get_ask_hn_digest_logger
 from core.forms import SendNewsletterForm, SummarizeHNDiscussionForm
 from core.models import HNDiscussionSummary, Tag, TagAlias, TopicLane
+from core.seo import (
+    DEFAULT_DESCRIPTION,
+    absolute_url,
+    blog_post_schema,
+    discussion_description,
+    discussion_title,
+    post_image_url,
+    social_image_url,
+    static_url,
+    website_schema,
+)
 
 logger = get_ask_hn_digest_logger(__name__)
+
+
+def paginated_canonical_url(request, view_name, page_obj, **kwargs):
+    path = reverse(view_name, kwargs=kwargs or None)
+    if page_obj.number > 1:
+        path = f"{path}?page={page_obj.number}"
+    return absolute_url(request, path)
+
+
+def robots_txt(request):
+    lines = [
+        "User-agent: *",
+        "Disallow: /admin/",
+        "Disallow: /admin-panel",
+        "Disallow: /api/",
+        "",
+        f"Sitemap: {absolute_url(request, '/sitemap.xml')}",
+        "",
+    ]
+    return HttpResponse("\n".join(lines), content_type="text/plain")
 
 
 class HomeView(TemplateView):
@@ -22,6 +54,24 @@ class HomeView(TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        canonical_url = absolute_url(self.request, reverse("home"))
+        social_image = social_image_url(
+            self.request,
+            title="Ask HN Digest",
+            description=DEFAULT_DESCRIPTION,
+            image_url=static_url(self.request, "vendors/images/logo.png"),
+            style="logo",
+            site="meta",
+        )
+        context["canonical_url"] = canonical_url
+        context["seo_description"] = DEFAULT_DESCRIPTION
+        context["social_image_url"] = social_image
+        context["website_schema"] = website_schema(
+            self.request,
+            url=canonical_url,
+            description=DEFAULT_DESCRIPTION,
+            image_url=social_image,
+        )
         context["latest_summaries"] = HNDiscussionSummary.objects.order_by("-date_analyzed")[:3]
         return context
 
@@ -65,6 +115,28 @@ class BlogView(ListView):
     def get_queryset(self):
         return HNDiscussionSummary.objects.prefetch_related("tags").order_by("-date_analyzed")
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        page_obj = context["page_obj"]
+        page_suffix = f" - Page {page_obj.number}" if page_obj.number > 1 else ""
+        context["page_suffix"] = page_suffix
+        context["canonical_url"] = paginated_canonical_url(self.request, "blog_posts", page_obj)
+        context["social_image_url"] = social_image_url(
+            self.request,
+            title=f"Ask HN Digest Archive{page_suffix}",
+            description=DEFAULT_DESCRIPTION,
+            image_url=static_url(self.request, "vendors/images/logo.png"),
+            style="logo",
+        )
+        context["website_schema"] = website_schema(
+            self.request,
+            url=context["canonical_url"],
+            name="Ask HN Digest Archive",
+            description=DEFAULT_DESCRIPTION,
+            image_url=context["social_image_url"],
+        )
+        return context
+
 
 class BlogPostView(DetailView):
     model = HNDiscussionSummary
@@ -73,6 +145,32 @@ class BlogPostView(DetailView):
 
     def get_queryset(self):
         return HNDiscussionSummary.objects.prefetch_related("tags")
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        summary = self.object
+        post_url = absolute_url(self.request, summary.get_absolute_url())
+        seo_title = f"{discussion_title(summary)} | Ask HN Digest"
+        seo_description = discussion_description(summary)
+        image_url = post_image_url(self.request, summary)
+        generated_social_image_url = social_image_url(
+            self.request,
+            title=seo_title,
+            description=seo_description,
+            image_url=image_url,
+        )
+
+        context["canonical_url"] = post_url
+        context["seo_title"] = seo_title
+        context["seo_description"] = seo_description
+        context["social_image_url"] = generated_social_image_url
+        context["blog_post_schema"] = blog_post_schema(
+            self.request,
+            summary,
+            url=post_url,
+            image_url=generated_social_image_url,
+        )
+        return context
 
 
 def test_mjml(request):
@@ -214,6 +312,7 @@ class TagDetailView(ListView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        page_obj = context["page_obj"]
         context["tag"] = self.tag
         context["tag_slug"] = self.tag.slug
         context["tag_aliases"] = list(self.tag.aliases.all())
@@ -223,6 +322,13 @@ class TagDetailView(ListView):
             .filter(topic_lane=self.tag.topic_lane)
             .exclude(id=self.tag.id)
             .order_by("-summary_count", "name")[:12]
+        )
+        context["page_suffix"] = f" - Page {page_obj.number}" if page_obj.number > 1 else ""
+        context["canonical_url"] = paginated_canonical_url(
+            self.request,
+            "tag_detail",
+            page_obj,
+            tag_slug=self.tag.slug,
         )
         return context
 

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -1,4 +1,5 @@
 {% load webpack_loader static %}
+{% load seo_extras %}
 <!DOCTYPE html>
 <html lang="en">
     <head>
@@ -15,26 +16,28 @@
         {% block meta %}
             <title>Ask HN Digest</title>
             <meta name="description"
-                  content="Get Summaries of the most engaging discussions on Hacker News" />
+                  content="{{ seo_description|default:'Get summaries of the most engaging discussions on Hacker News.' }}" />
             <meta name="keywords" content="Hacker News, summaries, newsletter, digest" />
             <meta name="robots" content="index, follow" />
-            <link rel="canonical" href="https://{{ request.get_host }}/" />
+            <link rel="canonical"
+                  href="{% if canonical_url %}{{ canonical_url }}{% else %}https://{{ request.get_host }}/{% endif %}" />
             <meta property="og:type" content="website" />
             <meta property="og:title" content="Ask HN Digest" />
-            <meta property="og:url" content="https://{{ request.get_host }}/" />
+            <meta property="og:url"
+                  content="{% if canonical_url %}{{ canonical_url }}{% else %}https://{{ request.get_host }}/{% endif %}" />
             <meta property="og:description"
-                  content="Get Summaries of the most engaging discussions on Hacker News" />
+                  content="{{ seo_description|default:'Get summaries of the most engaging discussions on Hacker News.' }}" />
             <meta property="og:image"
-                  content="https://osig.app/g?site=meta&style=logo&font=markerfelt&title=Ask HN Digest&subtitle=Get Summaries of the most engaging discussions on Hacker News&image_url=https://{{ request.get_host }}{% static 'vendors/images/logo.svg' %}" />
+                  content="{% if social_image_url %}{{ social_image_url }}{% else %}https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}{% endif %}" />
             <meta property="og:locale" content="en_US" />
             <meta name="twitter:card" content="summary" />
             <meta name="twitter:creator" content="@rasulkireev" />
             <meta name="twitter:site" content="@rasulkireev" />
             <meta name="twitter:title" content="Ask HN Digest" />
             <meta name="twitter:description"
-                  content="Get Summaries of the most engaging discussions on Hacker News" />
+                  content="{{ seo_description|default:'Get summaries of the most engaging discussions on Hacker News.' }}" />
             <meta name="twitter:image"
-                  content="https://osig.app/g?site=x&style=logo&font=markerfelt&title=Ask HN Digest&subtitle=Get Summaries of the most engaging discussions on Hacker News&image_url=https://{{ request.get_host }}{% static 'vendors/images/logo.svg' %}" />
+                  content="{% if social_image_url %}{{ social_image_url }}{% else %}https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}{% endif %}" />
         {% endblock meta %}
         <script defer
                 data-domain="askhndigests.com"
@@ -145,12 +148,15 @@
         </div>
         {% block schema %}
             <script type="application/ld+json">
+                {% if website_schema %}
+                    {{ website_schema|json_ld }}
+                {% else %}
     {
       "@context": "https://schema.org",
       "@type": "WebSite",
       "name": "Ask HN Digest",
       "description": "Get Summaries of the most engaging discussions on Hacker News",
-      "thumbnailUrl": "https://osig.app/g?site=x&style=logo&font=markerfelt&title=Ask HN Digest&subtitle=Get Summaries of the most engaging discussions on Hacker News&image_url=https://{{ request.get_host }}{% static 'vendors/images/logo.svg' %}",
+      "thumbnailUrl": "https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}",
       "url": "https://{{ request.get_host }}/",
       "author": {
         "@type": "Person",
@@ -159,6 +165,7 @@
         "url": "https://rasulkireev.com/"
       }
     }
+                {% endif %}
             </script>
         {% endblock schema %}
     </body>

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -155,7 +155,7 @@
       "@context": "https://schema.org",
       "@type": "WebSite",
       "name": "Ask HN Digest",
-      "description": "Get Summaries of the most engaging discussions on Hacker News",
+      "description": "Get summaries of the most engaging discussions on Hacker News.",
       "thumbnailUrl": "https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}",
       "url": "https://{{ request.get_host }}/",
       "author": {

--- a/frontend/templates/blog/blog_post.html
+++ b/frontend/templates/blog/blog_post.html
@@ -9,7 +9,7 @@
     <meta name="robots" content="index, follow" />
     <link rel="canonical" href="{{ canonical_url }}" />
     <meta property="og:type" content="article" />
-    <meta property="og:title" content="{{ blog_post.title }}" />
+    <meta property="og:title" content="{{ seo_title }}" />
     <meta property="og:url" content="{{ canonical_url }}" />
     <meta property="og:description" content="{{ seo_description }}" />
     <meta property="og:image" content="{{ social_image_url }}" />
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:creator" content="@rasulkireev" />
     <meta name="twitter:site" content="@rasulkireev" />
-    <meta name="twitter:title" content="{{ blog_post.title }}" />
+    <meta name="twitter:title" content="{{ seo_title }}" />
     <meta name="twitter:description" content="{{ seo_description }}" />
     <meta name="twitter:image" content="{{ social_image_url }}" />
 {% endblock meta %}

--- a/frontend/templates/blog/blog_post.html
+++ b/frontend/templates/blog/blog_post.html
@@ -1,28 +1,25 @@
 {% extends "base.html" %}
 {% load webpack_loader static %}
 {% load markdown_extras %}
+{% load seo_extras %}
 {% block meta %}
-    <title>{{ blog_post.title }} | Ask HN Digest Blog</title>
-    <meta name="description" content="{{ blog_post.description }}" />
+    <title>{{ seo_title }}</title>
+    <meta name="description" content="{{ seo_description }}" />
     <meta name="keywords" content="{{ blog_post.tag_keywords }}" />
     <meta name="robots" content="index, follow" />
-    <link rel="canonical"
-          href="https://{{ request.get_host }}{{ blog_post.get_absolute_url }}" />
+    <link rel="canonical" href="{{ canonical_url }}" />
     <meta property="og:type" content="article" />
     <meta property="og:title" content="{{ blog_post.title }}" />
-    <meta property="og:url"
-          content="https://{{ request.get_host }}{{ blog_post.get_absolute_url }}" />
-    <meta property="og:description" content="{{ blog_post.description }}" />
-    <meta property="og:image"
-          content="https://osig.app/g?site=x&style=base&font=markerfelt&title={{ blog_post.title }} | Ask HN Digest Blog&subtitle={{ blog_post.description }}&image_url={{ blog_post.image.url }}" />
+    <meta property="og:url" content="{{ canonical_url }}" />
+    <meta property="og:description" content="{{ seo_description }}" />
+    <meta property="og:image" content="{{ social_image_url }}" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:creator" content="@rasulkireev" />
     <meta name="twitter:site" content="@rasulkireev" />
     <meta name="twitter:title" content="{{ blog_post.title }}" />
-    <meta name="twitter:description" content="{{ blog_post.description }}" />
-    <meta name="twitter:image"
-          content="https://osig.app/g?site=x&style=base&font=markerfelt&title={{ blog_post.title }} | Ask HN Digest Blog&subtitle={{ blog_post.description }}&image_url={{ blog_post.image.url }}" />
+    <meta name="twitter:description" content="{{ seo_description }}" />
+    <meta name="twitter:image" content="{{ social_image_url }}" />
 {% endblock meta %}
 {% block content %}
     <article class="mx-auto max-w-6xl px-4 py-10 sm:px-6 sm:py-16"
@@ -111,34 +108,5 @@
     </section>
 {% endblock content %}
 {% block schema %}
-    <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "BlogPosting",
-    "headline": "{{ blog_post.title }}",
-    "description": "{{ blog_post.description }}",
-    "image": "https://osig.app/g?site=x&style=base&font=markerfelt&title={{ blog_post.title }} | Ask HN Digest Blog&subtitle={{ blog_post.description }}&image_url={{ blog_post.image.url }}",
-    "url": "https://{{ request.get_host }}{{ blog_post.get_absolute_url }}",
-    "datePublished": "{{ blog_post.created_at|date:'c' }}",
-    "dateModified": "{{ blog_post.updated_at|date:'c' }}",
-    "author": {
-      "@type": "Person",
-      "name": "Rasul Kireev",
-      "url": "https://rasulkireev.com/"
-    },
-    "publisher": {
-      "@type": "Organization",
-      "name": "Ask HN Digest",
-      "logo": {
-        "@type": "ImageObject",
-        "url": "https://{{ request.get_host }}{% static 'vendors/images/logo.svg' %}"
-      }
-    },
-    "articleBody": "{{ blog_post.long_summary|safe|replace_quotes }}",
-    "mainEntityOfPage": {
-      "@type": "WebPage",
-      "@id": "https://{{ request.get_host }}{{ blog_post.get_absolute_url }}"
-    }
-  }
-    </script>
+    <script type="application/ld+json">{{ blog_post_schema|json_ld }}</script>
 {% endblock schema %}

--- a/frontend/templates/blog/blog_post.html
+++ b/frontend/templates/blog/blog_post.html
@@ -9,7 +9,7 @@
     <meta name="robots" content="index, follow" />
     <link rel="canonical" href="{{ canonical_url }}" />
     <meta property="og:type" content="article" />
-    <meta property="og:title" content="{{ seo_title }}" />
+    <meta property="og:title" content="{{ social_title }}" />
     <meta property="og:url" content="{{ canonical_url }}" />
     <meta property="og:description" content="{{ seo_description }}" />
     <meta property="og:image" content="{{ social_image_url }}" />
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:creator" content="@rasulkireev" />
     <meta name="twitter:site" content="@rasulkireev" />
-    <meta name="twitter:title" content="{{ seo_title }}" />
+    <meta name="twitter:title" content="{{ social_title }}" />
     <meta name="twitter:description" content="{{ seo_description }}" />
     <meta name="twitter:image" content="{{ social_image_url }}" />
 {% endblock meta %}

--- a/frontend/templates/blog/blog_posts.html
+++ b/frontend/templates/blog/blog_posts.html
@@ -2,31 +2,28 @@
 {% load webpack_loader static %}
 {% load markdown_extras %}
 {% load core_extras %}
+{% load seo_extras %}
 {% block meta %}
-    <title>Ask HN Digest Blog</title>
+    <title>Ask HN Digest Archive{{ page_suffix }}</title>
     <meta name="description"
-          content="Get Summaries of the most engaging discussions on Hacker News" />
+          content="Browse summarized Hacker News discussions from Ask HN Digest{{ page_suffix }}." />
     <meta name="keywords" content="" />
     <meta name="robots" content="index, follow" />
-    <link rel="canonical"
-          href="https://{{ request.get_host }}{% url 'blog_posts' %}" />
+    <link rel="canonical" href="{{ canonical_url }}" />
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="Ask HN Digest Blog" />
-    <meta property="og:url"
-          content="https://{{ request.get_host }}{% url 'blog_posts' %}" />
+    <meta property="og:title" content="Ask HN Digest Archive{{ page_suffix }}" />
+    <meta property="og:url" content="{{ canonical_url }}" />
     <meta property="og:description"
-          content="Get Summaries of the most engaging discussions on Hacker News" />
-    <meta property="og:image"
-          content="https://osig.app/g?site=x&style=logo&font=markerfelt&title=Ask HN Digest Blog&subtitle=Get Summaries of the most engaging discussions on Hacker News&image_url=https://{{ request.get_host }}{% static 'vendors/images/logo.svg' %}" />
+          content="Browse summarized Hacker News discussions from Ask HN Digest{{ page_suffix }}." />
+    <meta property="og:image" content="{{ social_image_url }}" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:creator" content="@rasulkireev" />
     <meta name="twitter:site" content="@rasulkireev" />
-    <meta name="twitter:title" content="Ask HN Digest Blog" />
+    <meta name="twitter:title" content="Ask HN Digest Archive{{ page_suffix }}" />
     <meta name="twitter:description"
-          content="Get Summaries of the most engaging discussions on Hacker News" />
-    <meta name="twitter:image"
-          content="https://osig.app/g?site=x&style=logo&font=markerfelt&title=Ask HN Digest Blog&subtitle=Get Summaries of the most engaging discussions on Hacker News&image_url=https://{{ request.get_host }}{% static 'vendors/images/logo.svg' %}" />
+          content="Browse summarized Hacker News discussions from Ask HN Digest{{ page_suffix }}." />
+    <meta name="twitter:image" content="{{ social_image_url }}" />
 {% endblock meta %}
 {% block content %}
     <section class="mx-auto max-w-7xl px-4 py-10 sm:px-6 sm:py-16">
@@ -91,20 +88,5 @@
     </section>
 {% endblock content %}
 {% block schema %}
-    <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "WebSite",
-    "name": "Ask HN Digest Blog",
-    "description": "Get Summaries of the most engaging discussions on Hacker News",
-    "thumbnailUrl": "https://osig.app/g?site=x&style=logo&font=markerfelt&title=Ask HN Digest Blog&subtitle=Get Summaries of the most engaging discussions on Hacker News&image_url=https://{{ request.get_host }}{% static 'vendors/images/logo.svg' %}",
-    "url": "https://{{ request.get_host }}{% url 'blog_posts' %}",
-    "author": {
-      "@type": "Person",
-      "givenName": "Rasul",
-      "familyName": "Kireev",
-      "url": "https://rasulkireev.com/"
-    }
-  }
-    </script>
+    <script type="application/ld+json">{{ website_schema|json_ld }}</script>
 {% endblock schema %}

--- a/frontend/templates/pages/bookmarked_articles.html
+++ b/frontend/templates/pages/bookmarked_articles.html
@@ -5,6 +5,7 @@
 {% block meta %}
     <title>{{ page_title }} - Ask HN Digest</title>
     <meta name="description" content="{{ page_description }}" />
+    <meta name="robots" content="noindex, follow" />
     <meta property="og:title" content="{{ page_title }}" />
     <meta property="og:description" content="{{ page_description }}" />
     <meta name="twitter:title" content="{{ page_title }}" />

--- a/frontend/templates/pages/liked_articles.html
+++ b/frontend/templates/pages/liked_articles.html
@@ -5,6 +5,7 @@
 {% block meta %}
     <title>{{ page_title }} - Ask HN Digest</title>
     <meta name="description" content="{{ page_description }}" />
+    <meta name="robots" content="noindex, follow" />
     <meta property="og:title" content="{{ page_title }}" />
     <meta property="og:description" content="{{ page_description }}" />
     <meta name="twitter:title" content="{{ page_title }}" />

--- a/frontend/templates/pages/tag_detail.html
+++ b/frontend/templates/pages/tag_detail.html
@@ -2,12 +2,11 @@
 {% load static %}
 {% load markdown_extras %}
 {% block meta %}
-    <title>{{ tag.name }} - Ask HN Digest</title>
+    <title>{{ tag.name }} - Ask HN Digest{{ page_suffix }}</title>
     <meta name="description"
-          content="Browse all discussion summaries tagged with {{ tag.name }}." />
+          content="Browse summarized Hacker News discussions tagged with {{ tag.name }}{{ page_suffix }}." />
     <meta name="robots" content="index, follow" />
-    <link rel="canonical"
-          href="https://{{ request.get_host }}{% url 'tag_detail' tag_slug=tag_slug %}" />
+    <link rel="canonical" href="{{ canonical_url }}" />
 {% endblock meta %}
 {% block content %}
     <section class="mx-auto max-w-7xl px-4 py-10 sm:px-6 sm:py-16">
@@ -23,8 +22,10 @@
                 {% if tag_aliases %}
                     Also matches
                     {% for alias in tag_aliases %}
-                        {{ alias.name }}{% if not forloop.last %}, {% endif %}
-                    {% endfor %}.
+                        {{ alias.name }}
+                        {% if not forloop.last %},{% endif %}
+                    {% endfor %}
+                    .
                 {% else %}
                     All summarized Hacker News discussions tagged with this topic.
                 {% endif %}
@@ -48,9 +49,9 @@
                     <nav class="flex flex-wrap justify-center gap-1.5"
                          aria-label="Tag pagination">
                         {% if page_obj.has_previous %}
-                            <a href="?page=1{% if request.GET.urlencode %}&{{ request.GET.urlencode }}{% endif %}"
+                            <a href="?page=1"
                                class="inline-flex min-h-[2.35rem] min-w-[2.35rem] items-center justify-center rounded-[2px] border border-line bg-paper px-3 text-sm font-extrabold no-underline hover:border-line-strong">First</a>
-                            <a href="?page={{ page_obj.previous_page_number }}{% if request.GET.urlencode %}&{{ request.GET.urlencode }}{% endif %}"
+                            <a href="?page={{ page_obj.previous_page_number }}"
                                class="inline-flex min-h-[2.35rem] min-w-[2.35rem] items-center justify-center rounded-[2px] border border-line bg-paper px-3 text-sm font-extrabold no-underline hover:border-line-strong">Previous</a>
                         {% endif %}
                         {% for num in page_obj.paginator.page_range %}


### PR DESCRIPTION
## Summary
- add robots.txt and include tag archive pages in sitemap coverage with tag `lastmod` dates
- move article/home/archive JSON-LD to structured Python dictionaries rendered through safe JSON serialization
- add page-specific canonical URLs for paginated archive and tag pages
- noindex local liked/bookmarked pages and tighten generated article title/description metadata
- centralize encoded social image URL generation with static fallback for local builds
- preserve the normalized Tag/TagAlias/TopicLane flow from main after rebase

## Validation
- `python3 -m compileall ask_hn_digest core`
- `uv run ruff check ask_hn_digest/sitemaps.py ask_hn_digest/urls.py core/views.py core/seo.py core/templatetags/seo_extras.py core/tests/test_tags.py`
- `uv run ruff format --check ask_hn_digest/sitemaps.py ask_hn_digest/urls.py core/views.py core/seo.py core/templatetags/seo_extras.py core/tests/test_tags.py`
- `uv run djlint frontend/templates/base.html frontend/templates/blog/blog_post.html frontend/templates/blog/blog_posts.html frontend/templates/pages/tag_detail.html frontend/templates/pages/liked_articles.html frontend/templates/pages/bookmarked_articles.html --check`
- `LOGFIRE_SEND_TO_LOGFIRE=false ... uv run python manage.py check` (passes with existing `staticfiles.W004` warning because `frontend/build` is absent locally)
- Docker/Postgres: `docker compose run --rm --no-deps ... backend pytest core/tests/test_tags.py -q` (`8 passed`)
- JSON-LD smoke test with quotes, tags, ampersands, and newlines parsed successfully with `json.loads`

## Review status
- PR is ready for review and mergeable
- Greptile latest review: `Confidence Score: 5/5` on `a3a3a4b3`
- Unresolved review threads: `0`
- GitHub PR checks: none reported; current workflows only run deploy jobs on pushes to `main`